### PR TITLE
@W-8306895@ For MongoDB TLS auth, allow ignoring of invalid hostnames + Java driver upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.evergage.thirdparty.mongodb</groupId>
+            <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
             <version>${mongo-java-driver.version}</version>
         </dependency>        
@@ -56,7 +56,7 @@
         </plugins>
     </build>
     <properties>
-        <mongo-java-driver.version>3.8.3-evg3</mongo-java-driver.version>
+        <mongo-java-driver.version>3.12.8</mongo-java-driver.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.evergage.thirdparty.mongo-store</groupId>
     <artifactId>mongo-store</artifactId>
-    <version>1.6.5-evg3</version>
+    <version>1.6.5-evg4</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -65,6 +65,7 @@ public class MongoManager implements Manager, Lifecycle {
   // Mongo client SSL support directly from PEM bundles
   private String sslKeyStorePem;
   private String sslTrustStorePem;
+  private boolean sslInvalidHostNameAllowed;
 
   @Override
   public Container getContainer() {
@@ -198,6 +199,14 @@ public class MongoManager implements Manager, Lifecycle {
 
   public void setSslTrustStorePem(String sslTrustStorePem) {
     this.sslTrustStorePem = sslTrustStorePem;
+  }
+
+  public boolean isSslInvalidHostNameAllowed() {
+    return sslInvalidHostNameAllowed;
+  }
+
+  public void setSslInvalidHostNameAllowed(boolean sslInvalidHostNameAllowed) {
+    this.sslInvalidHostNameAllowed = sslInvalidHostNameAllowed;
   }
 
   public void load() throws ClassNotFoundException, IOException {
@@ -556,6 +565,7 @@ public class MongoManager implements Manager, Lifecycle {
         SSLContext sslContext = sslContextFromPEMs(new File(sslTrustStorePem), new File(sslKeyStorePem));
         clientOptionsBuilder.sslEnabled(true);
         clientOptionsBuilder.sslContext(sslContext);
+        clientOptionsBuilder.sslInvalidHostNameAllowed(sslInvalidHostNameAllowed);
         mongoCredentials.add(MongoCredential.createMongoX509Credential());
       } else {
         log.info("Using an unencrypted connection to Mongo");


### PR DESCRIPTION
Adds a boolean property `sslInvalidHostNameAllowed` which can allow invalid hostnames during SSL authentication.

Upgrades Java driver to a recent 3.12.x publicly released MongoDB build.