### PR TITLE
Follow up for W-8306895: fix latest mongo driver not working with local dev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.evergage.thirdparty.mongo-store</groupId>
     <artifactId>mongo-store</artifactId>
-    <version>1.6.5-evg5</version>
+    <version>1.6.5-evg6</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -570,7 +570,9 @@ public class MongoManager implements Manager, Lifecycle {
       Builder clientOptionsBuilder = MongoClientOptions.builder()
               .description("TomcatMongoSession[path=" + path + "]")
               .alwaysUseMBeans(true)
-              .connectionsPerHost(connectionsPerHost);
+              .connectionsPerHost(connectionsPerHost)
+              .retryReads(false)
+              .retryWrites(false);
 
       List<MongoCredential> mongoCredentials = new ArrayList<>();
 


### PR DESCRIPTION
The Mongo driver was upgraded from 3.8 to 3.12. Unfortunately, this caused retryable reads and writes to be turned on, which prevents this from working with certain developer Mongo setups.

This PR undoes the defaults change and turns off retryable reads and writes.