### PR TITLE
Fix invalid time units in startup log line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.evergage.thirdparty.mongo-store</groupId>
     <artifactId>mongo-store</artifactId>
-    <version>2.0.0-evg1</version>
+    <version>2.0.0-evg2</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -305,7 +305,7 @@ public class MongoManager implements Manager, Lifecycle {
       log.log(Level.SEVERE, "Unable to load serializer", e);
       throw new LifecycleException(e);
     }
-    log.info("Will expire sessions after " + getContext().getSessionTimeout() + " seconds");
+    log.info("Will expire sessions after " + getContext().getSessionTimeout() + " minutes");
     initDbConnection(getPath());
   }
 


### PR DESCRIPTION
This also bumps up version number up.

GUS: W-9611964