### PR TITLE
Delete CODEOWNERS to use org default

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-#GUSINFO:MCIS - Operations Team,MCIS Operations
-*


### PR DESCRIPTION
The org default in evergage/sfdc-codeowners will take effect