### PR TITLE
@W-16385452@ Fixes for findSession() to conform to API contract

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,16 +34,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.12.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -56,6 +55,7 @@
         </plugins>
     </build>
     <properties>
+        <java.version>21</java.version>
         <mongo-java-driver.version>3.12.8</mongo-java-driver.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     </build>
     <properties>
         <java.version>21</java.version>
-        <mongo-java-driver.version>3.12.8</mongo-java-driver.version>
+        <mongo-java-driver.version>3.12.14</mongo-java-driver.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.evergage.thirdparty.mongo-store</groupId>
     <artifactId>mongo-store</artifactId>
-    <version>2.0.0-evg3</version>
+    <version>2.0.0-evg4</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -443,7 +443,7 @@ public class MongoManager implements Manager, Lifecycle {
     }
   }
 
-  public Session loadSession(String id) throws IOException {
+  private Session loadSession(String id) throws IOException {
 
     if (id == null || id.length() == 0) {
       return createEmptySession();

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -412,6 +412,10 @@ public class MongoManager implements Manager, Lifecycle {
       }
 
       byte[] data = (byte[]) dbsession.get("data");
+      if (dbsession.get("data") == null) {
+        log.log(Level.WARNING, "Session object found in mongo for ID " + id + " but 'data' field was NULL");
+        return null;
+      }
 
       StandardSession session = (MongoSession) createEmptySession();
       session.setId(id);

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -447,7 +448,7 @@ public class MongoManager implements Manager, Lifecycle {
 
   private Session loadSession(String id) throws IOException {
 
-    if (id == null || id.length() == 0) {
+    if (id == null || id.isEmpty()) {
       return createEmptySession();
     }
 
@@ -469,11 +470,8 @@ public class MongoManager implements Manager, Lifecycle {
     }
 
     if (log.isLoggable(Level.FINE)) {
-      log.fine("Session Contents [" + clipSessionId(session.getId()) + "]:");
-      var names = session.getAttributeNames();
-      while (names.hasMoreElements()) {
-        log.fine("  " + names.nextElement());
-      }
+      log.fine("Session Contents [" + clipSessionId(session.getId()) + "] - " +
+        String.join(", ", Collections.list(session.getAttributeNames())));
     }
 
     log.fine(() -> "Loaded session id " + clipSessionId(id));
@@ -511,7 +509,6 @@ public class MongoManager implements Manager, Lifecycle {
       log.fine(() -> "Updated session with id " + session.getIdInternal());
     } catch (IOException e) {
       log.severe(e.getMessage());
-      e.printStackTrace();
       throw e;
     } finally {
       currentSession.remove();

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -402,6 +402,11 @@ public class MongoManager implements Manager, Lifecycle {
   private StandardSession findSessionInMongo(String id) throws IOException {
     try {
       log.fine(() -> "Loading session " + id + " from Mongo");
+
+      if (id == null || id.isEmpty()) {
+        return null;
+      }
+
       BasicDBObject query = new BasicDBObject();
       query.put("_id", id);
 

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -271,7 +271,7 @@ public class MongoManager implements Manager, Lifecycle {
   public org.apache.catalina.Session createSession(java.lang.String sessionId) {
     StandardSession session = (MongoSession) createEmptySession();
 
-    log.fine("Created session with id " + session.getIdInternal() + " ( " + clipSessionId(sessionId) + ")");
+    log.fine(() -> "Created session with id " + session.getIdInternal() + " ( " + clipSessionId(sessionId) + ")");
     if (sessionId != null) {
       session.setId(sessionId);
     }
@@ -452,17 +452,17 @@ public class MongoManager implements Manager, Lifecycle {
       return createEmptySession();
     }
 
-    StandardSession session = currentSession.get();
+    StandardSession cachedSession = currentSession.get();
 
-    if (session != null) {
-      if (id.equals(session.getId())) {
-        return session;
+    if (cachedSession != null) {
+      if (id.equals(cachedSession.getId())) {
+        return cachedSession;
       } else {
         currentSession.remove();
       }
     }
 
-    session = findSessionInMongo(id);
+    StandardSession session = findSessionInMongo(id);
     if (session == null) {
       log.fine(() -> "Session " + clipSessionId(id) + " not found in Mongo. Creating a new session.");
       session = getNewSession();
@@ -474,7 +474,6 @@ public class MongoManager implements Manager, Lifecycle {
         String.join(", ", Collections.list(session.getAttributeNames())));
     }
 
-    log.fine(() -> "Loaded session id " + clipSessionId(id));
     currentSession.set(session);
     return session;
   }
@@ -485,12 +484,8 @@ public class MongoManager implements Manager, Lifecycle {
 
       StandardSession standardsession = (MongoSession) session;
 
-      if (log.isLoggable(Level.FINE)) {
-        log.fine("Session Contents [" + clipSessionId(session.getId()) + "]:");
-        for (Object name : Collections.list(standardsession.getAttributeNames())) {
-          log.fine("  " + name);
-        }
-      }
+      log.fine(() ->"Session Contents [" + clipSessionId(session.getId()) + "] - " +
+              String.join(", ", Collections.list(standardsession.getAttributeNames())));
 
       byte[] data = serializer.serializeFrom(standardsession);
 

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -20,12 +20,31 @@
 
 package com.dawsonsystems.session;
 
-import com.mongodb.*;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientOptions.Builder;
+import com.mongodb.MongoCredential;
+import com.mongodb.ReadPreference;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteConcern;
+import com.mongodb.WriteResult;
 import com.mongodb.internal.dns.DefaultDnsResolver;
 import com.mongodb.internal.dns.DnsResolver;
-import com.mongodb.lang.Nullable;
-import org.apache.catalina.*;
+import org.apache.catalina.Context;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleListener;
+import org.apache.catalina.LifecycleState;
+import org.apache.catalina.Loader;
+import org.apache.catalina.Manager;
+import org.apache.catalina.Session;
+import org.apache.catalina.SessionIdGenerator;
+import org.apache.catalina.Valve;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.session.StandardSession;
 
@@ -40,7 +59,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -24,6 +24,7 @@ import com.mongodb.*;
 import com.mongodb.MongoClientOptions.Builder;
 import com.mongodb.internal.dns.DefaultDnsResolver;
 import com.mongodb.internal.dns.DnsResolver;
+import com.mongodb.lang.Nullable;
 import org.apache.catalina.*;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.session.StandardSession;
@@ -269,7 +270,7 @@ public class MongoManager implements Manager, Lifecycle {
   public org.apache.catalina.Session createSession(java.lang.String sessionId) {
     StandardSession session = (MongoSession) createEmptySession();
 
-    log.fine("Created session with id " + session.getIdInternal() + " ( " + sessionId + ")");
+    log.fine("Created session with id " + session.getIdInternal() + " ( " + clipSessionId(sessionId) + ")");
     if (sessionId != null) {
       session.setId(sessionId);
     }
@@ -401,46 +402,47 @@ public class MongoManager implements Manager, Lifecycle {
 
   private StandardSession findSessionInMongo(String id) throws IOException {
     try {
-      log.fine(() -> "Loading session " + id + " from Mongo");
+      log.fine(() -> "Loading session " + clipSessionId(id) + " from Mongo");
 
       if (id == null || id.isEmpty()) {
         return null;
       }
 
-      BasicDBObject query = new BasicDBObject();
-      query.put("_id", id);
-
+      BasicDBObject query = new BasicDBObject("_id", id);
       DBObject dbsession = getCollection().findOne(query);
-
       if (dbsession == null) {
         return null;
       }
 
       byte[] data = (byte[]) dbsession.get("data");
-      if (dbsession.get("data") == null) {
-        log.log(Level.WARNING, "Session object found in mongo for ID " + id + " but 'data' field was NULL");
+      if (data == null) {
+        log.log(Level.WARNING, "Session object found in mongo for ID " + clipSessionId(id) + " but 'data' field was NULL");
         return null;
       }
 
-      StandardSession session = (MongoSession) createEmptySession();
-      session.setId(id);
-      session.setManager(this);
-      serializer.deserializeInto(data, session);
-
-      session.setMaxInactiveInterval(-1);
-      session.access();
-      session.setValid(true);
-      session.setNew(false);
-
-      return session;
+      return deserializePersistedSession(id, data);
 
     } catch (IOException e) {
-      log.severe(e.getMessage());
+      log.log(Level.SEVERE, "Failed to load session from Mongo", e);
       throw e;
     } catch (ClassNotFoundException ex) {
       log.log(Level.SEVERE, "Unable to deserialize session ", ex);
       throw new IOException("Unable to deserializeInto session", ex);
     }
+  }
+
+  private StandardSession deserializePersistedSession(String id, byte[] data) throws IOException, ClassNotFoundException {
+    StandardSession session = (MongoSession) createEmptySession();
+    session.setId(id);
+    session.setManager(this);
+    serializer.deserializeInto(data, session);
+
+    session.setMaxInactiveInterval(-1);
+    session.access();
+    session.setValid(true);
+    session.setNew(false);
+
+    return session;
   }
 
   private Session loadSession(String id) throws IOException {
@@ -461,19 +463,20 @@ public class MongoManager implements Manager, Lifecycle {
 
     session = findSessionInMongo(id);
     if (session == null) {
-      log.fine(() -> "Session " + id + " not found in Mongo. Creating a new session.");
+      log.fine(() -> "Session " + clipSessionId(id) + " not found in Mongo. Creating a new session.");
       session = getNewSession();
       session.setId(id);
     }
 
     if (log.isLoggable(Level.FINE)) {
-      log.fine("Session Contents [" + session.getId() + "]:");
-      for (Object name : Collections.list(session.getAttributeNames())) {
-        log.fine("  " + name);
+      log.fine("Session Contents [" + clipSessionId(session.getId()) + "]:");
+      var names = session.getAttributeNames();
+      while (names.hasMoreElements()) {
+        log.fine("  " + names.nextElement());
       }
     }
 
-    log.fine(() -> "Loaded session id " + id);
+    log.fine(() -> "Loaded session id " + clipSessionId(id));
     currentSession.set(session);
     return session;
   }
@@ -485,7 +488,7 @@ public class MongoManager implements Manager, Lifecycle {
       StandardSession standardsession = (MongoSession) session;
 
       if (log.isLoggable(Level.FINE)) {
-        log.fine("Session Contents [" + session.getId() + "]:");
+        log.fine("Session Contents [" + clipSessionId(session.getId()) + "]:");
         for (Object name : Collections.list(standardsession.getAttributeNames())) {
           log.fine("  " + name);
         }
@@ -517,7 +520,7 @@ public class MongoManager implements Manager, Lifecycle {
   }
 
   public void remove(Session session) {
-    log.fine(() -> "Removing session ID : " + session.getId());
+    log.fine(() -> "Removing session ID : " + clipSessionId(session.getId()));
     BasicDBObject query = new BasicDBObject();
     query.put("_id", session.getId());
 
@@ -565,6 +568,12 @@ public class MongoManager implements Manager, Lifecycle {
     } catch (Exception e) {
       throw new RuntimeException("Error looking up SSLContext from JNDI: ", e);
     }
+  }
+
+  private static String clipSessionId(String sessionId) {
+    return (sessionId == null || sessionId.length() <= 7)
+            ? sessionId
+            : sessionId.substring(0, 7);
   }
 
   private void initDbConnection(String path) throws LifecycleException {

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -334,7 +334,7 @@ public class MongoManager implements Manager, Lifecycle {
   }
 
   public Session findSession(String id) throws IOException {
-    return loadSession(id);
+    return findSessionInMongo(id);
   }
 
   public static String getHost() {
@@ -399,6 +399,41 @@ public class MongoManager implements Manager, Lifecycle {
   }
 
 
+  private StandardSession findSessionInMongo(String id) throws IOException {
+    try {
+      log.fine(() -> "Loading session " + id + " from Mongo");
+      BasicDBObject query = new BasicDBObject();
+      query.put("_id", id);
+
+      DBObject dbsession = getCollection().findOne(query);
+
+      if (dbsession == null) {
+        return null;
+      }
+
+      byte[] data = (byte[]) dbsession.get("data");
+
+      StandardSession session = (MongoSession) createEmptySession();
+      session.setId(id);
+      session.setManager(this);
+      serializer.deserializeInto(data, session);
+
+      session.setMaxInactiveInterval(-1);
+      session.access();
+      session.setValid(true);
+      session.setNew(false);
+
+      return session;
+
+    } catch (IOException e) {
+      log.severe(e.getMessage());
+      throw e;
+    } catch (ClassNotFoundException ex) {
+      log.log(Level.SEVERE, "Unable to deserialize session ", ex);
+      throw new IOException("Unable to deserializeInto session", ex);
+    }
+  }
+
   public Session loadSession(String id) throws IOException {
 
     if (id == null || id.length() == 0) {
@@ -414,50 +449,24 @@ public class MongoManager implements Manager, Lifecycle {
         currentSession.remove();
       }
     }
-    try {
-      log.fine(() -> "Loading session " + id + " from Mongo");
-      BasicDBObject query = new BasicDBObject();
-      query.put("_id", id);
 
-      DBObject dbsession = getCollection().findOne(query);
-
-      if (dbsession == null) {
-        log.fine(() -> "Session " + id + " not found in Mongo");
-        StandardSession ret = getNewSession();
-        ret.setId(id);
-        currentSession.set(ret);
-        return ret;
-      }
-
-      byte[] data = (byte[]) dbsession.get("data");
-
-      session = (MongoSession) createEmptySession();
+    session = findSessionInMongo(id);
+    if (session == null) {
+      log.fine(() -> "Session " + id + " not found in Mongo. Creating a new session.");
+      session = getNewSession();
       session.setId(id);
-      session.setManager(this);
-      serializer.deserializeInto(data, session);
-
-      session.setMaxInactiveInterval(-1);
-      session.access();
-      session.setValid(true);
-      session.setNew(false);
-
-      if (log.isLoggable(Level.FINE)) {
-        log.fine("Session Contents [" + session.getId() + "]:");
-        for (Object name : Collections.list(session.getAttributeNames())) {
-          log.fine("  " + name);
-        }
-      }
-
-      log.fine(() -> "Loaded session id " + id);
-      currentSession.set(session);
-      return session;
-    } catch (IOException e) {
-      log.severe(e.getMessage());
-      throw e;
-    } catch (ClassNotFoundException ex) {
-      log.log(Level.SEVERE, "Unable to deserialize session ", ex);
-      throw new IOException("Unable to deserializeInto session", ex);
     }
+
+    if (log.isLoggable(Level.FINE)) {
+      log.fine("Session Contents [" + session.getId() + "]:");
+      for (Object name : Collections.list(session.getAttributeNames())) {
+        log.fine("  " + name);
+      }
+    }
+
+    log.fine(() -> "Loaded session id " + id);
+    currentSession.set(session);
+    return session;
   }
 
   public void save(Session session) throws IOException {


### PR DESCRIPTION
These changes adjust the behaviour of the `MongoManager.findSession(id)` method to allow it to properly conform to the interface contract it is implementing. 

In particular, the findSession(id) method is intended to return a NULL in cases where the session identifier passed into the method is not found in Mongo. In the current version of the library this method will create a new default session, assign it the passed in identifier and return that. Due to this behaviour the findSession method will ALWAYS return a Session object, even in cases where one does not exist in Mongo. This breaks the interface contract and makes findSession() redundant with loadSession().

To facilitate these changes we created a new `findSessionInMongo(id)` method which returns NULL if no session is found in the database. The findSession(id) method calls findSessonInMongo() and directly returns the result while the loadSession() method makes use of findSessionInMongo() but will create a new default session if one is not found in Mongo. In this way both findSession() and loadSession() are able to share this common code but now individually conform to their interface definitions.
