### PR TITLE
@W-17371027@ basic Jakarta EE 10 support, not yet tested

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.evergage.thirdparty.mongo-store</groupId>
     <artifactId>mongo-store</artifactId>
-    <version>2.0.0-evg3</version>
+    <version>2.0.0-jakarta-ee10-evg4</version>
 
     <licenses>
         <license>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
-            <version>8.5.76</version>
+            <version>10.1.34</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/com/dawsonsystems/session/JavaSerializer.java
+++ b/src/main/java/com/dawsonsystems/session/JavaSerializer.java
@@ -23,7 +23,7 @@ package com.dawsonsystems.session;
 import org.apache.catalina.session.StandardSession;
 import org.apache.catalina.util.CustomObjectInputStream;
 
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSession;
 import java.io.*;
 
 

--- a/src/main/java/com/dawsonsystems/session/MongoManager.java
+++ b/src/main/java/com/dawsonsystems/session/MongoManager.java
@@ -237,11 +237,6 @@ public class MongoManager implements Manager, Lifecycle {
   }
 
   @Override
-  public void changeSessionId(Session session) {
-    session.setId(getSessionIdGenerator().generateSessionId());
-  }
-
-  @Override
   public void changeSessionId(Session session, String newId) {
     session.setId(newId);
   }
@@ -645,6 +640,26 @@ public class MongoManager implements Manager, Lifecycle {
   @Override
   public boolean willAttributeDistribute(String name, Object value) {
     return true;
+  }
+
+  @Override
+  public void setNotifyBindingListenerOnUnchangedValue(boolean notifyBindingListenerOnUnchangedValue) {
+    throw new UnsupportedOperationException("setNotifyBindingListenerOnUnchangedValue is not supported");
+  }
+
+  @Override
+  public void setNotifyAttributeListenerOnUnchangedValue(boolean notifyAttributeListenerOnUnchangedValue) {
+    throw new UnsupportedOperationException("setNotifyAttributeListenerOnUnchangedValue is not supported");
+  }
+
+  @Override
+  public void setSessionActivityCheck(boolean sessionActivityCheck) {
+    throw new UnsupportedOperationException("setSessionActivityCheck is not supported");
+  }
+
+  @Override
+  public void setSessionLastAccessAtStart(boolean sessionLastAccessAtStart) {
+    throw new UnsupportedOperationException("setSessionLastAccessAtStart is not supported");
   }
 
   @Override

--- a/src/main/java/com/dawsonsystems/session/MongoSessionTrackerValve.java
+++ b/src/main/java/com/dawsonsystems/session/MongoSessionTrackerValve.java
@@ -25,7 +25,7 @@ import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.logging.Logger;
 

--- a/src/main/java/com/dawsonsystems/session/Serializer.java
+++ b/src/main/java/com/dawsonsystems/session/Serializer.java
@@ -20,7 +20,7 @@
 
 package com.dawsonsystems.session;
 
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 
 public interface Serializer {


### PR DESCRIPTION
Need Jakarta EE 10 support because JDK23 only supported in Spring 6 which requires Jakarta EE 9 or 10.

Creating the PR before finishing testing in part because I need to publish this updated session manager to even get tomcat to start on jenkins build machines.